### PR TITLE
Add support for http auth

### DIFF
--- a/service/data.py
+++ b/service/data.py
@@ -27,7 +27,7 @@ class DataConnectionException(Exception):
     """
 
 
-def elasticsearch_connection(hosts, sniff=False, sniffer_timeout=60):
+def elasticsearch_connection(hosts, sniff=False, http_auth=False, sniffer_timeout=60):
     """Crea una conexión a Elasticsearch.
 
     Args:
@@ -44,13 +44,19 @@ def elasticsearch_connection(hosts, sniff=False, sniffer_timeout=60):
     """
     try:
         options = {
-            'hosts': hosts
+            'hosts': hosts,
+
         }
 
         if sniff:
             options['sniff_on_start'] = True
             options['sniff_on_connection_fail'] = True
             options['sniffer_timeout'] = sniffer_timeout
+        
+        if http_auth:
+            options['http_auth'] = http_auth
+
+        return elasticsearch.Elasticsearch(**options)
 
         return elasticsearch.Elasticsearch(**options)
     except elasticsearch.ElasticsearchException as e:

--- a/service/normalizer.py
+++ b/service/normalizer.py
@@ -4,7 +4,7 @@ Contiene funciones que manejan la lógica de procesamiento
 de los recursos que expone la API.
 """
 
-import logging
+import logging, os
 from flask import current_app
 from service import data, params, formatter, address, location, utils, street
 from service import names as N
@@ -26,10 +26,17 @@ def get_elasticsearch():
 
     """
     if not hasattr(current_app, 'elasticsearch'):
+        HTTP_AUTH_USER = os.environ.get("HTTP_AUTH_USER", "")
+        HTTP_AUTH_PASS = os.environ.get("HTTP_AUTH_PASS", "")
+        if HTTP_AUTH_USER and HTTP_AUTH_PASS:
+            auth = (HTTP_AUTH_USER, HTTP_AUTH_PASS)
+        else:
+            auth = False
         current_app.elasticsearch = data.elasticsearch_connection(
             hosts=current_app.config['ES_HOSTS'],
             sniff=current_app.config['ES_SNIFF'],
-            sniffer_timeout=current_app.config['ES_SNIFFER_TIMEOUT']
+            sniffer_timeout=current_app.config['ES_SNIFFER_TIMEOUT'],
+            http_auth=auth
         )
 
     return current_app.elasticsearch


### PR DESCRIPTION
Hi!
This adds support for supplying http_auth for the elasticsearch client used in the application.

This was needed for allowing access to our setup of elasticsearch.