### PR TITLE
fix: evitar KeyError por altura ausente en /ubicacion (#240)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 flake8==5.0.0
 pylint==2.17
 coverage==4.5.2

--- a/service/location.py
+++ b/service/location.py
@@ -33,11 +33,10 @@ def _address_full_name(sb, cl, dept, state):
     # lugar.
     fmt = {
         'street_name': sb['nombre'],
-        'door_number': sb['altura'],
+        'door_number': sb.get('altura') or '',
         'loc': cl[N.NAME],
         'state': state[N.NAME],
         'dept': dept[N.NAME],
-
     }
 
     template = '{street_name} {door_number}, {loc}, {dept}, {state}'


### PR DESCRIPTION
**Descripción:**

Este PR resuelve un error crítico (HTTP 500) que ocurría al realizar consultas al recurso /ubicacion
con coordenadas que no resultaban en una altura de calle válida.

**Cambios principales:**
 * Fix de `KeyError`: Se reemplazó el acceso directo por índice `sb['altura']` por el método seguro `sb.get('altura')` en la función `_address_full_name` de `service/location.py`.
* Mejora estética: Se añadió un fallback para que, en caso de ausencia de altura, el campo `door_number` sea un string vacío, evitando la aparición del literal "None" en la nomenclatura final de la dirección.
* Entorno de desarrollo: Se actualizó `requirements-dev.txt` para incluir las dependencias de producción (`-r requirements.txt`), facilitando la ejecución de tests y configuración de entornos locales.

**Investigación técnica:**
Durante el diagnóstico, se identificó que el bug afectaba a la rama development (que es la versión
que actualmente corre en el entorno de producción de la API pública), mientras que la rama master del
repositorio aún no integraba esta funcionalidad de geocodificación inversa detallada.
